### PR TITLE
Cache path length shortened

### DIFF
--- a/src/Oleander.Assembly.Versioning.BuildTask/Oleander.Assembly.Versioning.BuildTask.csproj
+++ b/src/Oleander.Assembly.Versioning.BuildTask/Oleander.Assembly.Versioning.BuildTask.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\Common\targets\common.targets" />
 
   <PropertyGroup>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <AssemblyVersion>0.2.1.0</AssemblyVersion>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <InformationalVersion>$(AssemblyVersion)</InformationalVersion>
     <Version>$(AssemblyVersion)</Version>

--- a/src/Oleander.Assembly.Versioning.Tool/Oleander.Assembly.Versioning.Tool.csproj
+++ b/src/Oleander.Assembly.Versioning.Tool/Oleander.Assembly.Versioning.Tool.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\..\Common\targets\common.targets" />
 
   <PropertyGroup>
-    <AssemblyVersion>0.1.47.2</AssemblyVersion>
-    <SourceRevisionId>f8c27d824bd797522cbc3ebf5e15cc0e1cbd3c61</SourceRevisionId>
+    <AssemblyVersion>0.1.47.3</AssemblyVersion>
+    <SourceRevisionId>1fa6ea098fbd09d1d4c0655c53fa0e19f9b657a8</SourceRevisionId>
     <VersionSuffix>beta</VersionSuffix>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <InformationalVersion>$(AssemblyVersion)</InformationalVersion>

--- a/src/Oleander.Assembly.Versioning.Tool/Properties/launchSettings.json
+++ b/src/Oleander.Assembly.Versioning.Tool/Properties/launchSettings.json
@@ -8,6 +8,10 @@
       "commandName": "Project",
       "commandLineArgs": "update -t \"D:\\dev\\git\\oleander\\AssemblyVersioning\\src\\Oleander.Assembly.Versioning\\bin\\Debug\\net8.0\\Oleander.Assembly.Versioning.dll\""
     },
+    "Tool update D316IT012 Oleander.Assembly.Comparers": {
+      "commandName": "Project",
+      "commandLineArgs": "update -t \"D:\\dev\\git\\oleander\\AssemblyVersioning\\src\\Oleander.Assembly.Comparers\\bin\\Debug\\net8.0\\Oleander.Assembly.Comparers.dll\""
+    },
     "Tool update L316IT012 Tentakel.Database": {
       "commandName": "Project",
       "commandLineArgs": "update -t \"C:\\dev\\git\\tentakelDev\\Tentakel.DataAccess\\src\\Tentakel.Database\\bin\\Debug\\net48\\Tentakel.Database.dll\""

--- a/src/Oleander.Assembly.Versioning/FileSystems/FileSystem.cs
+++ b/src/Oleander.Assembly.Versioning/FileSystems/FileSystem.cs
@@ -178,7 +178,7 @@ internal class FileSystem(ILogger logger)
 
     #region CacheBaseDirInfo
 
-    public DirectoryInfo CacheBaseDirInfo => CreateDirectoryInfo(this.VersioningDirInfo, "cache", this.GitHash);
+    public DirectoryInfo CacheBaseDirInfo => CreateDirectoryInfo(this.VersioningDirInfo, "cache", this.GitHash.Length > 8 ? this.GitHash.Substring(0, 8) : this.GitHash);
 
     #endregion
 

--- a/src/Oleander.Assembly.Versioning/Oleander.Assembly.Versioning.csproj
+++ b/src/Oleander.Assembly.Versioning/Oleander.Assembly.Versioning.csproj
@@ -3,8 +3,8 @@
   <Import Project="..\..\Common\targets\common.targets" />
 
   <PropertyGroup>
-    <AssemblyVersion>0.1.86.0</AssemblyVersion>
-    <SourceRevisionId>0d672fbbb3c8c648b5bffa14d869437456abcda5</SourceRevisionId>
+    <AssemblyVersion>0.1.87.0</AssemblyVersion>
+    <SourceRevisionId>1fa6ea098fbd09d1d4c0655c53fa0e19f9b657a8</SourceRevisionId>
     <VersionSuffix>beta</VersionSuffix>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <InformationalVersion>$(AssemblyVersion)</InformationalVersion>

--- a/src/Oleander.Assembly.Versioning/Versioning.cs
+++ b/src/Oleander.Assembly.Versioning/Versioning.cs
@@ -408,6 +408,11 @@ internal class Versioning(ILogger logger)
 
         if (refTargetFileInfo.Exists) return;
 
+        if (refTargetFileInfo.FullName.Length >= 260)
+        {
+            logger.LogWarning("File name '{refTargetFile}' exceeds 260 characters! MSBuild does not support paths larger than 260 characters.", refTargetFileInfo.FullName);
+        }
+
         if (cacheBaseDirInfo.CreateDirectoryIfNotExist())
         {
             logger.LogInformation("Directory '{cacheBaseDir}' created.", cacheBaseDirInfo.FullName);
@@ -448,7 +453,7 @@ internal class Versioning(ILogger logger)
 
         if (refTargetFileInfo.CreateDirectoryIfNotExist())
         {
-            logger.LogInformation("Directory '{refTargetDir}' created.", refTargetFileInfo.DirectoryName);
+            logger.LogInformation("Directory '{refTargetDir}' was created.", refTargetFileInfo.DirectoryName);
         }
 
         var projectRefFileInfo = this.FileSystem.ProjectRefFileInfo;


### PR DESCRIPTION
Cache path length shortened. Only the first 8 characters of the Git hash are used in the path.